### PR TITLE
Demultiplexer timeout fix

### DIFF
--- a/src/sys/event_epoll.c
+++ b/src/sys/event_epoll.c
@@ -156,10 +156,11 @@ void pd_io_run(pd_io_t *ctx) {
         }
 
         pd_timers_run(ctx);
-        timeout = pd_timers_next(ctx);
         pd__tcp_pending_close(ctx);
 
         if (ctx->after_tick)
             ctx->after_tick(ctx);
+
+        timeout = pd_timers_next(ctx);
     }
 }

--- a/src/sys/event_iocp.c
+++ b/src/sys/event_iocp.c
@@ -109,10 +109,11 @@ void pd_io_run(pd_io_t *ctx) {
        }
 
         pd_timers_run(ctx);
-        timeout = pd_timers_next(ctx);
         pd__tcp_pending_close(ctx);
 
         if (ctx->after_tick)
             ctx->after_tick(ctx);
+
+        timeout = pd_timers_next(ctx);
     }
 }

--- a/src/sys/event_kqueue.c
+++ b/src/sys/event_kqueue.c
@@ -152,10 +152,11 @@ void pd_io_run(pd_io_t *ctx) {
         }
 
         pd_timers_run(ctx);
-        timeout = pd_timers_next(ctx);
         pd__tcp_pending_close(ctx);
 
         if (ctx->after_tick)
             ctx->after_tick(ctx);
+
+        timeout = pd_timers_next(ctx);
     }
 }


### PR DESCRIPTION
Fix operations order - demultiplexer timeout must be calculated at the end of event loop cycle.